### PR TITLE
Development

### DIFF
--- a/setup/python/documentation.md
+++ b/setup/python/documentation.md
@@ -4,7 +4,7 @@ author: Ben Taft
 copyright: (C) 2020 Landmark Acoustics LLC
 ---
 
-# How to Set Up Sphinx to Make Web Pages from Docstrings
+# Use Sphinx to Make Web Pages from Docstrings
 
 Go to the package directory
 ## Update the setup configuration

--- a/setup/python/index.md
+++ b/setup/python/index.md
@@ -10,4 +10,6 @@ copyright: (C) 2020 Landmark Acoustics LLC
 
 # [How to Set Up a Package](./package.md)
 
+# [How to Use Sphinx to Automatically Generate Documentation from Docstrings](./documentation.md)
+
 # [How to Set Up a Django Application](./django_app.md)


### PR DESCRIPTION
The how-to for sphinx documentation is now reachable from setup/python/index.md